### PR TITLE
Update text-character-change.xml

### DIFF
--- a/Russian/text-character-change.xml
+++ b/Russian/text-character-change.xml
@@ -7,31 +7,31 @@
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_KING</zType>
-		<Translation><![CDATA[<masculine_0>King<feminine>Queen<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Король<feminine>Королева<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_KING_CONSORT</zType>
-		<Translation><![CDATA[<masculine_0>King Consort<feminine>Queen Consort<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Супруга короля<feminine>Супруг королевы<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_KING_DOWAGER</zType>
-		<Translation><![CDATA[<masculine_0>King Dowager<feminine>Queen Dowager<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Вдовствующий король<feminine>Вдовствующая королева<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_PRINCE</zType>
-		<Translation><![CDATA[<masculine_0>Prince<feminine>Princess<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Принц<feminine>Принцесса<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_PRINCE_CONSORT</zType>
-		<Translation><![CDATA[<masculine_0>Prince Consort<feminine>Princess Consort<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Супруга принца<feminine>Супруг принцессы<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_DUKE</zType>
-		<Translation><![CDATA[<masculine_0>Duke<feminine>Duchess<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Герцог<feminine>Герцогиня<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_DUKE_CONSORT</zType>
-		<Translation><![CDATA[<masculine_0>Duke Consort<feminine>Duchess Consort<end> {0_name}]]></Translation>
+		<Translation><![CDATA[<masculine_0>Супргу Герцога<feminine>Супруг герцогини<end> {0_name}]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_COUNCIL</zType>
@@ -39,76 +39,76 @@
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_GENERAL</zType>
-		<Translation>Gen. {0_name}</Translation>
+		<Translation>Генерал {0_name}</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_GOVERNOR</zType>
-		<Translation>Gov. {0_name}</Translation>
+		<Translation>Губернатор {0_name}</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_TITLE_AGENT</zType>
-		<Translation>Agent {0_name}</Translation>
+		<Translation>Агент {0_name}</Translation>
 	</Entry>
 	<!-- Relation -->
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_YOU</zType>
-		<Translation>You!</Translation>
+		<Translation>Вы!</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_SPOUSE</zType>
-		<Translation><![CDATA[Your <masculine_0>Husband<feminine>Wife<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш супруг<feminine>Ваша супруга<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_CHILD</zType>
-		<Translation><![CDATA[Your <masculine_0>Son<feminine>Daughter<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш сын<feminine>Ваша дочь<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_GRANDCHILD</zType>
-		<Translation><![CDATA[Your <masculine_0>Grandson<feminine>Granddaughter<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш правнук<feminine>Ваша правнучка<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_DESCENDANT</zType>
-		<Translation>Your Descendant</Translation>
+		<Translation>Ваш потомок</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_PARENT</zType>
-		<Translation><![CDATA[Your <masculine_0>Father<feminine>Mother<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш отец<feminine>Ваша мать<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_GRANDPARENT</zType>
-		<Translation><![CDATA[Your <masculine_0>Grandfather<feminine>Grandmother<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш дед<feminine>Ваша бабушка<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_ANCESTOR</zType>
-		<Translation>Your Ancestor</Translation>
+		<Translation>Ваш предок</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_SIBLING</zType>
-		<Translation><![CDATA[Your <masculine_0>Brother<feminine>Sister<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш брат<feminine>Ваша сестра<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_SIBLING_IN_LAW</zType>
-		<Translation><![CDATA[Your <masculine_0>Brother-in-Law<feminine>Sister-in-Law<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш сводный брат<feminine>Ваша сводная сестра<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_HALF_SIBLING</zType>
-		<Translation><![CDATA[Your <masculine_0>Half-Brother<feminine>Half-Sister<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш единокровный брат<feminine>Ваша единокровная сестра<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_COUSIN</zType>
-		<Translation>Your Cousin</Translation>
+		<Translation><![CDATA[<masculine_0>Ваш двоюродный брат<feminine>Ваша двоюродная сестра<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_AUNT_UNCLE</zType>
-		<Translation><![CDATA[Your <masculine_0>Uncle<feminine>Aunt<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш дядя<feminine>Ваша тетя<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_NIECE_NEPHEW</zType>
-		<Translation><![CDATA[Your <masculine_0>Nephew<feminine>Niece<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш племянник<feminine>Ваша племянница<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_CHILD_IN_LAW</zType>
-		<Translation><![CDATA[Your <masculine_0>Son-in-Law<feminine>Daughter-in-Law<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш пасынок<feminine>Ваша падчерица<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_PARENT_IN_LAW</zType>
@@ -116,40 +116,40 @@
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_STEPCHILD</zType>
-		<Translation><![CDATA[Your <masculine_0>Stepson<feminine>Stepdaughter<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш крестник<feminine>Ваша крестница<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_STEPPARENT</zType>
-		<Translation><![CDATA[Your <masculine_0>Stepfather<feminine>Stepmother<end>]]></Translation>
+		<Translation><![CDATA[<masculine_0>Ваш крестный<feminine>Ваша крестная<end>]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_RELATIVE</zType>
-		<Translation>Your Relative</Translation>
+		<Translation>Ваш родственник</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_RELATION_IN_LAW</zType>
-		<Translation>Your In-Law</Translation>
+		<Translation><![CDATA[Родственник <masculine_0>супруга<feminine>супруги<end>]]></Translation>
 	</Entry>
 	<!-- Heir -->
 	<Entry>
 		<zType>TEXT_CHARACTER_HEIR_ORDER_1</zType>
-		<Translation>Heir</Translation>
+		<Translation>Наследник</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_HEIR_ORDER_2</zType>
-		<Translation>Second in Line</Translation>
+		<Translation>Второй наследник</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_HEIR_ORDER_3</zType>
-		<Translation>Third in Line</Translation>
+		<Translation>Третий наследник</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_HEIR_ORDER_4</zType>
-		<Translation>Fourth in Line</Translation>
+		<Translation>Четвертый наследник</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_HEIR_ORDER_X</zType>
-		<Translation>Distant Successor</Translation>
+		<Translation>Дальний наследник</Translation>
 	</Entry>
 	<!-- Misc -->
 	<Entry>
@@ -162,15 +162,15 @@
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_GENERAL_OF</zType>
-		<Translation>General of {0_unit}</Translation>
+		<Translation>Генерал {0_unit}</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_GOVERNOR_OF</zType>
-		<Translation>Governor of {0_city}</Translation>
+		<Translation>Губернатор {0_city}</Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_AGENT_IN</zType>
-		<Translation>Agent in {0_city}</Translation>
+		<Translation>Агент в {0_city}</Translation>
 	</Entry>
 	<!-- Name -->
 	<Entry>
@@ -191,23 +191,23 @@
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_OF_NATION</zType>
-		<Translation>{0_name} of {1_nation}</Translation>
+		<Translation>{0_name} из {1_nation}</Translation>
 	</Entry>
 	<!--Game Text-->
 	<Entry>
 		<zType>TEXT_CHARACTER_NEW_RULER</zType>
-		<Translation><![CDATA[Our old ruler is dead. Now begins the reign of {0_newLeader}. Long live the <masculine_0>King<feminine>Queen<end>!]]></Translation>
+		<Translation><![CDATA[Наш прежний правитель скончался. И сейчас начинается правление {0_newLeader}. Да здравствует <masculine_0>Король<feminine>Королева<end>!]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_COUNCIL_HAS_DIED</zType>
-		<Translation>Your {0_council}, {1_character}, has died!</Translation>
+		<Translation>Ваш {0_council}, {1_character} скончался!></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_HAS_DIED</zType>
-		<Translation>{0_character} has died!</Translation>
+		<Translation><![CDATA[{0_character} <masculine_0>скончался<feminine>скончалась<end>!]]></Translation>
 	</Entry>
 	<Entry>
 		<zType>TEXT_CHARACTER_LEADER_NEW_COGNOMEN</zType>
-		<Translation><![CDATA[<comment variable 0 is leader for gender purposes>You are now known as {1_cognomen}!]]></Translation>
+		<Translation><![CDATA[<comment variable 0 is leader for gender purposes>Теперь вы известны как {1_cognomen}!]]></Translation>
 	</Entry>
 </Root>


### PR DESCRIPTION
Я не смог протестировать изменения, т.к. текущий master крашит пол игры из-за отсутсвия текстов технологий.

- TEXT_CHARACTER_RELATION_HALF_SIBLING
В русском есть различается название в зависимости если родвство по матери или по отцу. Я взял по отцу ибо звучит баще.

- TEXT_CHARACTER_TITLE_GENERAL, TEXT_CHARACTER_TITLE_GOVERNOR
Были сокращения, а я использовал полное слово. имхо русские сокращения будут не понятны.

- TEXT_CHARACTER_RELATION_PARENT_IN_LAW
Ну тут не поймут если тестя, свекром назвать или наоборот. Если есть воможность вытаскивать пол жены/мужа через переменные то можно перевести нормально. Даже отцом супруга/и не назовешь, все равно надо пол знать...

- TEXT_COUNCIL_HAS_DIED
Намеренно не использовал род, т.к. агент, генерал, губернатор будут в мужском роде. Если кто-то будет и роли переводить в соответствии с полом, то нужно будет везде править(